### PR TITLE
Updating spark-jms-receiver to work with Spark 2.0.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-jms-receiver"
 
-version := "0.1.2"
+version := "0.2.0"
 
 scalaVersion := "2.11.6"
 
@@ -10,7 +10,7 @@ crossScalaVersions := Seq("2.10.4","2.11.6")
 
 spName := "tbfenet/spark-jms-receiver"
 
-val sparkVer = "1.6.0"
+val sparkVer = "2.0.0"
 
 sparkVersion := sparkVer
 
@@ -32,3 +32,4 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 
 )
+

--- a/src/main/scala/net/tbfe/spark/streaming/jms/JmsStreamUtils.scala
+++ b/src/main/scala/net/tbfe/spark/streaming/jms/JmsStreamUtils.scala
@@ -19,7 +19,7 @@ package net.tbfe.spark.streaming.jms
 import java.util.Properties
 import javax.jms._
 import javax.naming.InitialContext
-import org.apache.spark.Logging
+import org.apache.spark.streaming.jms.{ PublicLogging => Logging }
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.ReceiverInputDStream

--- a/src/main/scala/org/apache/spark/streaming/jms/JmsReceiver.scala
+++ b/src/main/scala/org/apache/spark/streaming/jms/JmsReceiver.scala
@@ -19,12 +19,19 @@ package org.apache.spark.streaming.jms
 import com.google.common.base.Stopwatch
 import java.util.concurrent._
 import javax.jms._
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.apache.spark.storage.{StorageLevel, StreamBlockId}
 import org.apache.spark.streaming.receiver.{BlockGenerator, BlockGeneratorListener, Receiver}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
+
+/**
+ * Trait used to expose the logging interface to the rest of this library.
+ *
+ * Simply grabs Logging, which is package-private, and exposes it by giving it another name.
+ */
+trait PublicLogging extends Logging
 
 /**
  * Reliable receiver for a JMS source


### PR DESCRIPTION
Not much was needed for this change. I chose to keep using the internal logger, since that required minimal code changes, but it might be a good idea to also update spark-jms-receiver to do a different logging method, instead of my hack to expose the Logger trait.