### PR TITLE
Added support for credentials on JMS queue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-jms-receiver"
 
-version := "0.2.0"
+version := "0.2.1"
 
 scalaVersion := "2.11.6"
 

--- a/src/main/scala/net/tbfe/spark/streaming/jms/JmsStreamUtils.scala
+++ b/src/main/scala/net/tbfe/spark/streaming/jms/JmsStreamUtils.scala
@@ -18,6 +18,7 @@ package net.tbfe.spark.streaming.jms
 
 import java.util.Properties
 import javax.jms._
+import javax.naming.Context
 import javax.naming.InitialContext
 import org.apache.spark.streaming.jms.{ PublicLogging => Logging }
 import org.apache.spark.storage.StorageLevel
@@ -27,7 +28,7 @@ import org.apache.spark.streaming.jms._
 import org.apache.spark.streaming.receiver.{BlockGeneratorListener, Receiver}
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
-
+import scala.collection.JavaConverters._
 
 
 object JmsStreamUtils {
@@ -165,7 +166,16 @@ case class JndiMessageConsumerFactory(jndiProperties: Properties,
     val connectionFactory = initialContext
       .lookup(connectionFactoryName).asInstanceOf[ConnectionFactory]
 
-    val createConnection: Connection = connectionFactory.createConnection()
+    val props = jndiProperties.asScala
+    val username = props.get(Context.SECURITY_PRINCIPAL)
+    val password = props.get(Context.SECURITY_CREDENTIALS)
+
+    val createConnection: Connection = (username, password) match {
+      case (Some(username), Some(password)) =>
+        connectionFactory.createConnection(username, password)
+      case _ =>
+        connectionFactory.createConnection()
+    }
     createConnection
   }
 

--- a/src/main/scala/net/tbfe/spark/streaming/jms/JmsStreamUtils.scala
+++ b/src/main/scala/net/tbfe/spark/streaming/jms/JmsStreamUtils.scala
@@ -18,8 +18,7 @@ package net.tbfe.spark.streaming.jms
 
 import java.util.Properties
 import javax.jms._
-import javax.naming.Context
-import javax.naming.InitialContext
+import javax.naming.{Context, InitialContext}
 import org.apache.spark.streaming.jms.{ PublicLogging => Logging }
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContext


### PR DESCRIPTION
This PR adds the ability to set credentials to use on the JMS queue. They use the same property keys as JNDI expects, so it will mesh well with existing JMS codebases.

After this PR is merged, could we get the latest version pushed to spark-packages?